### PR TITLE
記述ミスの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ has_many :users, through => :groups_users
 has_many :messages  
 has_many :groups, through => :groups_users
 ##### index
-add_index :groups_users, [:name]
+add_index :users, :name
 
 ***
 


### PR DESCRIPTION
# WHAT
README.mdに記述したデータベース設計の、usersテーブルにおけるindexの記述を修正

# WHY
usersテーブルのカラムに対する設定なので、groups_usersではなくusersが適切だから